### PR TITLE
feat: pytest에서 function 단위로 rollback 을 작성할 수 있도록 합니다

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,11 +4,10 @@ on:
   push:
     paths:
       - "app/**"
-  #   branches:
-  #     - '*'
-  #     - '!main' # main will be protected by pull request
+    branches:
+      - main 
   pull_request:
-    types: [opened, synchronize]
+    types: [synchronize]
     paths:
       - "app/**"
 

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -14,9 +14,11 @@ SessionLocal = sessionmaker(
 )
 Base = declarative_base()
 
+
 def get_db():
     db = SessionLocal()
     try:
         yield db
+        db.commit()
     finally:
         db.close()

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -24,7 +24,7 @@ def create_user(db: Session, email: str, plain_password: str):
     db_user = User(email=email, hashed_password=hashed_password)
     try:
         db.add(db_user)
-        db.commit()
+        db.flush()
         db.refresh(db_user)
     except IntegrityError:
         raise email_already_exists_exception
@@ -55,5 +55,5 @@ def reset_password(db: Session, uuid: UUID, email: str, password: str) -> None:
         raise user_not_exists_exception
     db_user.hashed_password = password
     db.add(db_user)
-    db.commit()
+    db.flush()
     return None

--- a/app/tests/apis/v1/test_root.py
+++ b/app/tests/apis/v1/test_root.py
@@ -1,11 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from app.main import app
 
-client = TestClient(app)
-
-
-def test_root():
+def test_root(client):
     response = client.get("/")
     assert response.status_code == 200

--- a/app/tests/apis/v1/test_user.py
+++ b/app/tests/apis/v1/test_user.py
@@ -4,29 +4,29 @@ from app.models.user import User
 from app.services import user as user_service
 
 
-def test_user_create(db: Session):
+def test_user_create(session: Session):
     email = "test@test.com"
     password = "test1234"
     user = user_service.create_user(
-        db,
+        session,
         email=email,
         plain_password=password,
     )
 
-    db_user = db.query(User).filter(User.email == email).one()
+    db_user = session.query(User).filter(User.email == email).one()
     assert db_user
     assert db_user.email == user.email == email
 
 
-def test_user_second(db: Session):
+def test_user_second(session: Session):
     email = "test@test.com"
     password = "test1234"
     user = user_service.create_user(
-        db,
+        session,
         email=email,
         plain_password=password,
     )
 
-    db_user = db.query(User).filter(User.email == email).one()
+    db_user = session.query(User).filter(User.email == email).one()
     assert db_user
     assert db_user.email == user.email == email

--- a/app/tests/apis/v1/test_user.py
+++ b/app/tests/apis/v1/test_user.py
@@ -4,29 +4,29 @@ from app.models.user import User
 from app.services import user as user_service
 
 
-def test_user_create(session: Session):
+def test_user_create(db):
     email = "test@test.com"
     password = "test1234"
     user = user_service.create_user(
-        session,
+        db,
         email=email,
         plain_password=password,
     )
 
-    db_user = session.query(User).filter(User.email == email).one()
+    db_user = db.query(User).filter(User.email == email).one()
     assert db_user
     assert db_user.email == user.email == email
 
 
-def test_user_second(session: Session):
+def test_user_second(db):
     email = "test@test.com"
     password = "test1234"
     user = user_service.create_user(
-        session,
+        db,
         email=email,
         plain_password=password,
     )
 
-    db_user = session.query(User).filter(User.email == email).one()
+    db_user = db.query(User).filter(User.email == email).one()
     assert db_user
     assert db_user.email == user.email == email

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,15 +1,16 @@
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from app.db.base import Base
 from app.db.session import get_db
 from app.main import app
 
-SQLALCHEMY_DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/test"
+TEST_DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/test"
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL,
+    TEST_DATABASE_URL,
 )
 TestingSessionLocal = sessionmaker(
     autocommit=False,
@@ -33,11 +34,30 @@ client = TestClient(app)
 
 @pytest.fixture(autouse=True, scope="session")
 def db():
+    # assert TEST_DATABASE_URL.endswith("test")
+    # if database_exists(TEST_DATABASE_URL):
+    #     drop_database(TEST_DATABASE_URL)
+    # create_database(TEST_DATABASE_URL)
+
     try:  # TODO: change logic BETA for Change if Table exists
-        Base.metadata.drop_all(bind=engine)
         Base.metadata.create_all(bind=engine)
         test_db = TestingSessionLocal()
         yield test_db
     finally:
         test_db.close()
         Base.metadata.drop_all(bind=engine)
+
+    # drop_database(TEST_DATABASE_URL)
+
+
+@pytest.fixture
+def engine(db: Session) -> Session:
+    db.begin_nested()
+    yield db
+    db.rollback()
+
+
+@pytest.fixture
+def client(session):
+    app.dependency_overrides[get_db] = lambda: session
+    return TestClient(app)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -43,8 +43,8 @@ def _sessionmaker():
     drop_database(TEST_DATABASE_URL)
 
 
-@pytest.fixture(scope="function")
-def db(_sessionmaker):
+@pytest.fixture(scope="function", name="db")
+def _db(_sessionmaker):
     try:
         test_db: Session = _sessionmaker()
         test_db.begin_nested()
@@ -54,15 +54,15 @@ def db(_sessionmaker):
         test_db.close()
 
 
-@pytest.fixture(scope="function")
-def client(db):
+@pytest.fixture(scope="function", name="client")
+def _client(db):
     app.dependency_overrides[get_db] = lambda: db
-    with TestClient(app) as client:
-        yield client
+    with TestClient(app) as test_client:
+        yield test_client
 
 
-@pytest.fixture(scope="module")
-def db_module(_sessionmaker):
+@pytest.fixture(scope="module", name="db_module")
+def _db_module(_sessionmaker):
     try:
         test_db: Session = _sessionmaker()
         test_db.begin_nested()
@@ -75,5 +75,5 @@ def db_module(_sessionmaker):
 @pytest.fixture(scope="module")
 def client_module(db_module):
     app.dependency_overrides[get_db] = lambda: db_module
-    with TestClient(app) as client:
-        yield client
+    with TestClient(app) as test_client:
+        yield test_client

--- a/app/tests/services/test_user.py
+++ b/app/tests/services/test_user.py
@@ -5,7 +5,7 @@ from app.models.user import User
 from app.services import user as user_service
 
 
-def test_create_user(db: Session):
+def test_create_user(db):
     user = user_service.create_user(
         db=db,
         email="sungwook.csw@gmail.com",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ psycopg2 = "^2.9.6"
 celery = "^5.3.1"
 pytest = "^7.4.0"
 bcrypt = "^4.0.1"
+sqlalchemy-utils = "^0.41.1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
pytest 에서 같은 file(module) 내에서 같은 이메일의 유저를 생성할 수 없습니다.
이를 유저가 조정할 수 있도록 합니다.

scope 가 다른 db를 두개 만들어서 경우에 따라 사용할 수 있습니다.

서비스에 작성된 db.commit()을 db.flush() 로 변경합니다.
db.flush 가 실패하면, dependency 에서 db.rollback()을 진행하여
의존성에 의존하는 transaction을 구현합니다.